### PR TITLE
Add Social Links to Footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,9 +1,10 @@
 import React from 'react';
 import styled from 'styled-components';
 import { rem } from 'polished';
+import { FaDiscord as DiscordIcon, FaTwitter as TwitterIcon } from 'react-icons/fa';
 import { Divider } from '@mantine/core';
 import { GitPOAP } from './shared/elements/icons/GitPOAP';
-import { BackgroundPanel2, TextGray } from '../colors';
+import { BackgroundPanel2, ExtraHover, TextGray } from '../colors';
 
 const Content = styled.div`
   display: flex;
@@ -22,7 +23,34 @@ const Container = styled.div`
   line-height: ${rem(17)};
   letter-spacing: ${rem(0.5)};
   color: ${TextGray};
-  padding: ${rem(20)} 0;
+  padding: ${rem(32)} 0;
+`;
+
+const ContentLeft = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const ContentRight = styled.div`
+  display: inline-flex;
+  flex-direction: row;
+  align-items: center;
+`;
+
+const SocialLink = styled.a`
+  text-decoration: none;
+  color: inherit;
+
+  &:hover {
+    color: ${ExtraHover};
+  }
+
+  svg {
+    height: ${rem(24)};
+    margin: 0 ${rem(12)};
+    width: ${rem(24)};
+  }
 `;
 
 export const Footer = () => {
@@ -30,11 +58,18 @@ export const Footer = () => {
     <Content>
       <Divider style={{ borderTopColor: BackgroundPanel2 }} />
       <Container>
-        <div>
+        <ContentLeft>
           <GitPOAP style={{ marginRight: rem(8) }} />
           {'GitPOAP 2022'}
-        </div>
-        <div>{'Get in touch team@gitpoap.io'}</div>
+        </ContentLeft>
+        <ContentRight>
+          <SocialLink href={'https://gitpoap.io/discord'}>
+            <DiscordIcon />
+          </SocialLink>
+          <SocialLink href={'https://twitter.com/gitpoap'}>
+            <TwitterIcon />
+          </SocialLink>
+        </ContentRight>
       </Container>
     </Content>
   );


### PR DESCRIPTION
https://www.notion.so/gitpoap/Frontend-Landing-Add-Social-Icons-Links-to-Footer-Navbar-afc3a979067340389f14c12d651fbff5

Adds Discord and Twitter Links to the Footer
<img width="705" alt="image" src="https://user-images.githubusercontent.com/19416312/158683017-eb6ed4c2-cdf2-43cf-8688-2c5c80c94a76.png">

Future discussion topic:
The Footer and Header might look nice if their width was confined in a similar way to the page content. 
(See https://ceramic.network/ for example)