### PR TITLE
Prevent the page from scrolling on changing the Sort By Value of the GitPOAP Page

### DIFF
--- a/src/components/gitpoap/GitPOAPHolders.tsx
+++ b/src/components/gitpoap/GitPOAPHolders.tsx
@@ -6,7 +6,6 @@ import { useGitPoapHoldersQuery } from '../../graphql/generated-gql';
 import { InfoHexSummary } from './InfoHexSummary';
 import { ItemList, SelectOption } from '../shared/compounds/ItemList';
 import { EmptyState } from '../shared/compounds/ItemListEmptyState';
-import { POAPBadgeSkeleton } from '../shared/elements/Skeletons';
 import { Text } from '../shared/elements/Text';
 import { TextDarkGray } from '../../colors';
 
@@ -66,11 +65,15 @@ export const GitPOAPHolders = ({ gitPOAPId }: Props) => {
   useEffect(() => {
     setHolders((prev: Holder[]) => {
       if (result.data?.gitPOAPHolders) {
-        return [...prev, ...result.data.gitPOAPHolders.holders];
+        if (page === 1) {
+          return [...result.data.gitPOAPHolders.holders];
+        } else {
+          return [...prev, ...result.data.gitPOAPHolders.holders];
+        }
       }
       return prev;
     });
-  }, [result.data]);
+  }, [page, result.data]);
 
   /* Hook to set total number of poaps */
   useEffect(() => {
@@ -91,7 +94,6 @@ export const GitPOAPHolders = ({ gitPOAPId }: Props) => {
       onSelectChange={(sortValue) => {
         if (sortValue !== sort) {
           setSort(sortValue as SortOptions);
-          setHolders([]);
           setPage(1);
         }
       }}
@@ -103,13 +105,7 @@ export const GitPOAPHolders = ({ gitPOAPId }: Props) => {
         }
       }}
     >
-      {result.fetching ? (
-        <>
-          {[...Array(5)].map((_, i) => {
-            return <POAPBadgeSkeleton key={i} height={rem(215)} />;
-          })}
-        </>
-      ) : total ? (
+      {total ? (
         <HoldersWrapper>
           {holders.map((holder: Holder) => (
             <InfoHexSummary

--- a/src/components/shared/elements/Skeletons.tsx
+++ b/src/components/shared/elements/Skeletons.tsx
@@ -3,14 +3,10 @@ import { rem } from 'polished';
 import { Skeleton } from '@mantine/core';
 import { BackgroundPanel2, BackgroundPanel } from '../../../colors';
 
-type Props = {
-  height?: string;
-};
-
-export const POAPBadgeSkeleton = (props: Props & React.ComponentProps<typeof Skeleton>) => {
+export const POAPBadgeSkeleton = (props: React.ComponentProps<typeof Skeleton>) => {
   return (
     <Skeleton
-      height={props.height ?? rem(150)}
+      height={rem(150)}
       circle
       sx={(_) => ({
         '&::after': {


### PR DESCRIPTION
https://www.notion.so/gitpoap/Frontend-GitPOAP-page-additional-polish-60b33e372338498c924597f412f6fcca

Add a loading state to GitPOAPHolders that maintains the page height
The loading state has a page height of 100%, which is a simple but imperfect way of fixing the issue
