### PR TITLE
Remove poapSecret from admin upload codes

### DIFF
--- a/src/pages/admin/codes.tsx
+++ b/src/pages/admin/codes.tsx
@@ -48,7 +48,6 @@ const GetUniqueGitPOAPQuery = gql`
   query gitPOAP($poapEventId: Int!) {
     gitPOAP(where: { poapEventId: $poapEventId }) {
       id
-      poapSecret
       poapEventId
       status
       repo {


### PR DESCRIPTION
This isn't used anywhere and can't be requested anyways since it is blocked from the outputs.

Ref: https://github.com/gitpoap/gitpoap-backend/pull/113