### PR TITLE
Add null coalesce to static gen return obj

### DIFF
--- a/src/pages/gh/[orgName]/[repoName].tsx
+++ b/src/pages/gh/[orgName]/[repoName].tsx
@@ -72,6 +72,7 @@ export const getStaticProps = async (
   return {
     props: {
       urqlState: ssrCache.extractData(),
+      /* coalesce to null if no data is returned -> nextJS doesn't like 'undefined' */
       data: results.data ?? null,
     },
   };

--- a/src/pages/gh/[orgName]/index.tsx
+++ b/src/pages/gh/[orgName]/index.tsx
@@ -67,7 +67,8 @@ export const getStaticProps = async (context: GetStaticPropsContext<{ orgName: s
   return {
     props: {
       urqlState: ssrCache.extractData(),
-      data: results.data,
+      /* coalesce to null if no data is returned -> nextJS doesn't like 'undefined' */
+      data: results.data ?? null,
     },
   };
 };

--- a/src/pages/gp/[id].tsx
+++ b/src/pages/gp/[id].tsx
@@ -115,7 +115,7 @@ export const getStaticProps = async (context: GetStaticPropsContext<{ id: string
   return {
     props: {
       urqlState: ssrCache.extractData(),
-      gitpoap: results.data,
+      gitpoap: results.data ?? null,
     },
     revalidate: ONE_WEEK_IN_S,
   };

--- a/src/pages/org/[id].tsx
+++ b/src/pages/org/[id].tsx
@@ -83,7 +83,8 @@ export const getStaticProps = async (context: GetStaticPropsContext<{ id: string
   return {
     props: {
       urqlState: ssrCache.extractData(),
-      data: results.data,
+      /* coalesce to null if no data is returned -> nextJS doesn't like 'undefined' */
+      data: results.data ?? null,
     },
   };
 };

--- a/src/pages/rp/[id].tsx
+++ b/src/pages/rp/[id].tsx
@@ -84,7 +84,8 @@ export const getStaticProps = async (context: GetStaticPropsContext<{ id: string
   return {
     props: {
       urqlState: ssrCache.extractData(),
-      data: results.data,
+      /* coalesce to null if no data is returned -> nextJS doesn't like 'undefined' */
+      data: results.data ?? null,
     },
   };
 };


### PR DESCRIPTION
Summary: 
During vercel deployments to production, or even preview builds, we get errors due to these static page generation files returning `undefined` for data. 

nextJS seems to not like `undefined`, and prefers `null`. therefore, we change this code to coalesce to `null` to reduce the chance of failed builds. 