### PR TITLE
Add missing parens on vitals page in unminted claims percent

### DIFF
--- a/src/components/admin/VitalsDashboard.tsx
+++ b/src/components/admin/VitalsDashboard.tsx
@@ -208,7 +208,7 @@ export const VitalsDashboard = (props: Props) => {
               mintedClaims &&
               `${totalClaims - mintedClaims} (${
                 (((totalClaims - mintedClaims) / totalClaims) * 100).toFixed(2) + '%'
-              }`
+              })`
             }
             // value={totalClaims && mintedClaims && totalClaims - mintedClaims}
           />


### PR DESCRIPTION
Fixes an issue where there was no closing parens on the "Total unminted claims" stat on the vitals page: https://www.gitpoap.io/admin/vitals

<img width="520" alt="Screen Shot 2022-09-01 at 9 19 43 PM" src="https://user-images.githubusercontent.com/1555326/188038731-dc35b455-85d6-4af0-947d-e641b2954ecb.png">
