### PR TITLE
Fix truncate for empty string input

### DIFF
--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -10,6 +10,9 @@ export const truncateAddress = (
   startChars: number = 14,
   endChars: number = 4,
 ): string => {
+  if (address === '') {
+    return '';
+  }
   const checkSumAddress = utils.getAddress(address);
   return checkSumAddress.slice(0, startChars) + '...' + checkSumAddress.slice(-endChars);
 };


### PR DESCRIPTION
This is causing issues for searches on PROD.

(Sorry made this on my phone...)