### PR TITLE
Enable page-based custom layouts

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -71,7 +71,7 @@ const TheApp = ({ Component, pageProps }: Props) => {
                     <GlobalStyles />
                     <Layout>
                       <LoadingBar />
-                      <Component {...pageProps} />
+                      {getLayout(<Component {...pageProps} />)}
                     </Layout>
                   </ClaimContextProvider>
                 </FeaturesProvider>

--- a/src/pages/gh/[orgName]/[repoName].tsx
+++ b/src/pages/gh/[orgName]/[repoName].tsx
@@ -105,11 +105,6 @@ export const getStaticPaths = async () => {
   };
 };
 
-/* Custom layout function for this page */
-Repo.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default withUrqlClient(
   (_) => ({
     url: `${process.env.NEXT_PUBLIC_GITPOAP_API_URL}/graphql`,

--- a/src/pages/gh/[orgName]/index.tsx
+++ b/src/pages/gh/[orgName]/index.tsx
@@ -100,11 +100,6 @@ export const getStaticPaths = async () => {
   };
 };
 
-/* Custom layout function for this page */
-Organization.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default withUrqlClient(
   (_) => ({
     url: `${process.env.NEXT_PUBLIC_GITPOAP_API_URL}/graphql`,

--- a/src/pages/gp/[id].tsx
+++ b/src/pages/gp/[id].tsx
@@ -145,11 +145,6 @@ export const getStaticPaths = async () => {
   };
 };
 
-/* Custom layout function for this page */
-GitPOAP.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default withUrqlClient(
   (_) => ({
     url: `${process.env.NEXT_PUBLIC_GITPOAP_API_URL}/graphql`,

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
-import styled, { css } from 'styled-components';
+import styled from 'styled-components';
 import { rem } from 'polished';
 import { Center, Grid, Stack } from '@mantine/core';
 import { Page } from './_app';
 import { BackgroundPanel2 } from '../colors';
 import { BannerStats } from '../components/home/BannerStats';
-import { Layout } from '../components/Layout';
 import { MostClaimed } from '../components/home/MostClaimed';
 import { LeaderBoard } from '../components/home/LeaderBoard';
 import { RecentlyAdded } from '../components/home/RecentlyAdded';
@@ -102,11 +101,6 @@ const Home: Page = () => {
       </Grid>
     </>
   );
-};
-
-/* Custom layout function for this Home page */
-Home.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
 };
 
 export default Home;

--- a/src/pages/org/[id].tsx
+++ b/src/pages/org/[id].tsx
@@ -116,11 +116,6 @@ export const getStaticPaths = async () => {
   };
 };
 
-/* Custom layout function for this page */
-Organization.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default withUrqlClient(
   (_) => ({
     url: `${process.env.NEXT_PUBLIC_GITPOAP_API_URL}/graphql`,

--- a/src/pages/orgs/index.tsx
+++ b/src/pages/orgs/index.tsx
@@ -26,9 +26,4 @@ const Orgs: Page = () => {
   );
 };
 
-/* Custom layout function for this page */
-Orgs.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default Orgs;

--- a/src/pages/p/[id].tsx
+++ b/src/pages/p/[id].tsx
@@ -95,9 +95,4 @@ export const getStaticPaths = () => {
   return { paths: [], fallback: 'blocking' };
 };
 
-/* Custom layout function for this page */
-Profile.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default Profile;

--- a/src/pages/repos/index.tsx
+++ b/src/pages/repos/index.tsx
@@ -25,9 +25,4 @@ const Repos: Page = () => {
   );
 };
 
-/* Custom layout function for this page */
-Repos.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default Repos;

--- a/src/pages/rp/[id].tsx
+++ b/src/pages/rp/[id].tsx
@@ -117,11 +117,6 @@ export const getStaticPaths = async () => {
   };
 };
 
-/* Custom layout function for this page */
-Repo.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default withUrqlClient(
   (_) => ({
     url: `${process.env.NEXT_PUBLIC_GITPOAP_API_URL}/graphql`,

--- a/src/pages/s/[query].tsx
+++ b/src/pages/s/[query].tsx
@@ -28,9 +28,4 @@ const Search: Page = () => {
   );
 };
 
-/* Custom layout function for this page */
-Search.getLayout = (page: React.ReactNode) => {
-  return <Layout>{page}</Layout>;
-};
-
 export default Search;


### PR DESCRIPTION
Enable page-based custom layouts
Removes redundant layout setting for individual pages, as the global layout is already set [here](https://github.com/gitpoap/gitpoap-fe/blob/main/src/pages/_app.tsx#L72)

[NextJS documentation for Per-Page Layouts](https://nextjs.org/docs/basic-features/layouts#per-page-layouts)