### PR TITLE
Add unverified claims to vitals

### DIFF
--- a/src/components/admin/VitalsDashboard.tsx
+++ b/src/components/admin/VitalsDashboard.tsx
@@ -8,6 +8,7 @@ import {
   useCountClaimsWithPullRequestEarnedQuery,
   useGitPoaPsSinceQuery,
   useMintedClaimsCountQuery,
+  useUnverifiedClaimsCountQuery,
   useOrgsSinceQuery,
   useProfilesSinceQuery,
   useReposSinceQuery,
@@ -118,6 +119,7 @@ export const VitalsDashboard = (props: Props) => {
   const [totalProfilesHiddenResults] = useTotalProfilesHiddenQuery();
   const [totalClaimsResult] = useClaimsCountQuery();
   const [mintedClaimsResult] = useMintedClaimsCountQuery();
+  const [unverifiedClaimsResult] = useUnverifiedClaimsCountQuery();
   const [totalUsersResult] = useTotalUsersQuery();
   const [totalUsersWithClaimsResult] = useTotalDistinctUsersWithClaimsQuery();
   const [totalClaimsWithPullRequestEarnedResult] = useCountClaimsWithPullRequestEarnedQuery();
@@ -140,6 +142,7 @@ export const VitalsDashboard = (props: Props) => {
   const totalProfilesHidden = totalProfilesHiddenResults?.data?.aggregateProfile?._count?.id;
   const totalClaims = totalClaimsResult.data?.aggregateClaim._count?.id;
   const mintedClaims = mintedClaimsResult.data?.aggregateClaim._count?.id;
+  const unverifiedClaims = unverifiedClaimsResult.data?.aggregateClaim._count?.id;
   const totalUsers = totalUsersResult.data?.aggregateUser._count?.githubHandle;
   const totalUsersWithClaims = totalUsersWithClaimsResult.data?.claims.length;
   const totalClaimsWithPREarned =
@@ -214,6 +217,14 @@ export const VitalsDashboard = (props: Props) => {
               })`
             }
             // value={totalClaims && mintedClaims && totalClaims - mintedClaims}
+          />
+          <DashboardItem
+            name={'Total unverified claims'}
+            value={`${unverifiedClaims} (${
+              totalClaims && unverifiedClaims
+                ? ((unverifiedClaims / totalClaims) * 100).toFixed(2) + '%'
+                : ''
+            })`}
           />
           <DashboardItem
             name={'Total claims'}

--- a/src/graphql/generated-gql.tsx
+++ b/src/graphql/generated-gql.tsx
@@ -4992,6 +4992,16 @@ export type MintedClaimsCountQuery = {
   };
 };
 
+export type UnverifiedClaimsCountQueryVariables = Exact<{ [key: string]: never }>;
+
+export type UnverifiedClaimsCountQuery = {
+  __typename?: 'Query';
+  aggregateClaim: {
+    __typename?: 'AggregateClaim';
+    _count?: { __typename?: 'ClaimCountAggregate'; id: number } | null;
+  };
+};
+
 export type AllGitPoapIdsQueryVariables = Exact<{ [key: string]: never }>;
 
 export type AllGitPoapIdsQuery = {
@@ -6121,6 +6131,24 @@ export function useMintedClaimsCountQuery(
 ) {
   return Urql.useQuery<MintedClaimsCountQuery, MintedClaimsCountQueryVariables>({
     query: MintedClaimsCountDocument,
+    ...options,
+  });
+}
+export const UnverifiedClaimsCountDocument = gql`
+  query unverifiedClaimsCount {
+    aggregateClaim(where: { needsRevalidation: { equals: true } }) {
+      _count {
+        id
+      }
+    }
+  }
+`;
+
+export function useUnverifiedClaimsCountQuery(
+  options?: Omit<Urql.UseQueryArgs<UnverifiedClaimsCountQueryVariables>, 'query'>,
+) {
+  return Urql.useQuery<UnverifiedClaimsCountQuery, UnverifiedClaimsCountQueryVariables>({
+    query: UnverifiedClaimsCountDocument,
     ...options,
   });
 }

--- a/src/graphql/operations.graphql
+++ b/src/graphql/operations.graphql
@@ -574,6 +574,14 @@ query mintedClaimsCount {
   }
 }
 
+query unverifiedClaimsCount {
+  aggregateClaim(where: { needsRevalidation: { equals: true } }) {
+    _count {
+      id
+    }
+  }
+}
+
 query allGitPOAPIds {
   gitPOAPS {
     id


### PR DESCRIPTION
Adds a count of GitPOAPs that have been transferred and need to be reverified as being soulbound