### PR TITLE
Add query params to features context

### DIFF
--- a/src/components/FeaturesContext.tsx
+++ b/src/components/FeaturesContext.tsx
@@ -18,6 +18,7 @@ export const getInitialState = (): FeaturesState => ({
   hasCheckIfImEligible: false,
   hasClaimAllButton: true,
   hasOrganizations: false,
+  hasSettingsPage: false,
   hasTrendingReposPage: false,
 });
 


### PR DESCRIPTION
Checks whether any query params are present and equal to `"true"`, then updates the features context

