### PR TITLE
feat: Lint __tests__ dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "workerDirectory": "public"
   },
   "lint-staged": {
-    "src/**/*.{ts,tsx}": [
+    "{src,__tests__}/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
     ]


### PR DESCRIPTION
Summary: 
Add `__tests__` to the directories that are linted via pre-commit hook. 