### PR TITLE
Remove option for 1 gitpoap per repo

### DIFF
--- a/src/components/onboard/UploadDesigns.tsx
+++ b/src/components/onboard/UploadDesigns.tsx
@@ -62,13 +62,6 @@ export const UploadDesigns = ({
   values,
 }: Props) => (
   <Stack spacing="xl">
-    <RadioGroup orientation="vertical" required {...getInputProps('isOneGitPOAPPerRepo')}>
-      <Radio value="true" label={<Text>{'Separate GitPOAPS for each Repo'}</Text>} />
-      <Radio value="false" label={<Text>{'One GitPOAP across all Repos'}</Text>} />
-    </RadioGroup>
-
-    <Divider size="xs" style={{ color: BackgroundPanel2 }} />
-
     <RadioGroup orientation="vertical" required {...getInputProps('shouldGitPOAPDesign')}>
       <Radio value="true" label={<Text>{'Have us design your GitPOAPs'}</Text>} />
       <Radio


### PR DESCRIPTION
**Summary:** 
As discussed with Kayleen & Colfax, we will be removing the option for users to state that they want 1 gitpoap per repo. Rationale being that it's very time and $$ expensive to maintain this many gitpoaps. 

Here we remove the option for users to onboard w 1 gitpoap per repo. 