### PR TITLE
Use InfuraProvider to get wallet ENS and avatar

### DIFF
--- a/src/components/wallet/WalletStatus.tsx
+++ b/src/components/wallet/WalletStatus.tsx
@@ -50,7 +50,7 @@ export const WalletStatus = ({ address, onClick, ensName, hideText }: Props) => 
   useEffect(() => {
     const prepareResultsEns = async () => {
       if (ensName) {
-        const avatar = await (web3Provider ?? infuraProvider)?.getAvatar(ensName);
+        const avatar = await infuraProvider?.getAvatar(ensName);
         if (avatar) {
           setEnsAvatarUrl(avatar);
         }


### PR DESCRIPTION
Summary: 
Update code that fetches a wallet's ENS avatar and name to use `InfuraProvider`, which doesn't change the chainId like what web3Modal does. 