### PR TITLE
Change contributor copy to holders on repo & org page

### DIFF
--- a/src/components/organization/Header.tsx
+++ b/src/components/organization/Header.tsx
@@ -63,7 +63,7 @@ export const Header = ({ org }: Props) => (
       <SubHeaderItem>
         <People />
         <SubHeaderItemCount>{org.contributorCount}</SubHeaderItemCount>
-        <SubHeaderItemLabel>{'Contributors'}</SubHeaderItemLabel>
+        <SubHeaderItemLabel>{'Holders'}</SubHeaderItemLabel>
       </SubHeaderItem>
       <SubHeaderItem>
         <GitPOAP />

--- a/src/components/organization/OrgRepoList.tsx
+++ b/src/components/organization/OrgRepoList.tsx
@@ -19,7 +19,7 @@ export type OrgRepo = Exclude<
 const selectOptions: SelectOption<SortOptions>[] = [
   { value: 'alphabetical', label: 'Alphabetical' },
   { value: 'date', label: 'Creation Date' },
-  { value: 'contributor-count', label: 'Contributors' },
+  { value: 'contributor-count', label: 'Holders' },
   { value: 'minted-count', label: 'Minted Count' },
 ];
 

--- a/src/components/repo/Header.tsx
+++ b/src/components/repo/Header.tsx
@@ -160,7 +160,7 @@ export const Header = ({ repo }: Props) => {
         <SubHeaderItem>
           <People />
           <SubHeaderItemCount>{repo.contributorCount}</SubHeaderItemCount>
-          <SubHeaderItemLabel>{'Contributors'}</SubHeaderItemLabel>
+          <SubHeaderItemLabel>{'Holders'}</SubHeaderItemLabel>
         </SubHeaderItem>
         <SubHeaderItem>
           <GitPOAP />

--- a/src/components/repo/RepoLeaderBoard.tsx
+++ b/src/components/repo/RepoLeaderBoard.tsx
@@ -76,7 +76,7 @@ export const RepoLeaderBoard = ({ repoId }: RepoLeaderBoardProps) => {
   return (
     <Wrapper>
       <Content>
-        <HeaderStyled>{'Top contributors'}</HeaderStyled>
+        <HeaderStyled>{'Top holders'}</HeaderStyled>
         <List>
           {contributors && contributors?.length > 0 ? (
             contributors.map((contributor) => {


### PR DESCRIPTION
Summary: 
We got feedback from a project saying that they didn't like the look of `0 contributors`, when in fact they actually have a lot of contributors. 

Improved copy here would be holders to still refer tot he same set of users (those that hold the gitpoaps), without implying that the project is dead.