### PR TITLE
fix: filter out results that have no enabled gitpoaps

### DIFF
--- a/src/components/search/box/SearchBox.tsx
+++ b/src/components/search/box/SearchBox.tsx
@@ -157,14 +157,14 @@ export const SearchBox = ({ className }: Props) => {
   );
 
   const repos = useMemo(
-    () => repoResults.data?.repos.filter((repo) => repo.project.gitPOAPs.length > 0) || [],
+    () => repoResults.data?.repos.filter((repo) => repo.project.gitPOAPs.length > 0) ?? [],
     [repoResults.data?.repos],
   );
   const orgs = useMemo(
     () =>
       orgResults.data?.organizations.filter(
         (org) => org.repos.length > 0 && org.repos[0].project.gitPOAPs.length > 0,
-      ) || [],
+      ) ?? [],
     [orgResults.data?.organizations],
   );
   const gitPOAPs = gitPOAPResults.data?.gitPOAPS;

--- a/src/components/search/results/SearchResults.tsx
+++ b/src/components/search/results/SearchResults.tsx
@@ -55,11 +55,11 @@ export const SearchResults = ({ searchQuery }: Props) => {
     () =>
       orgResult.data?.organizations.filter(
         (org) => org.repos.length > 0 && org.repos[0].project.gitPOAPs.length > 0,
-      ) || [],
+      ) ?? [],
     [orgResult.data?.organizations],
   );
   const repos = useMemo(
-    () => repoResult.data?.repos.filter((repo) => repo.project.gitPOAPs.length > 0) || [],
+    () => repoResult.data?.repos.filter((repo) => repo.project.gitPOAPs.length > 0) ?? [],
     [repoResult.data?.repos],
   );
 


### PR DESCRIPTION
Summary: 
Filter out search results that don't have any enabled gitpoaps. The page would be empty & have no art if that is the case OR worse.. crash. 

This PR fixes this problem