### PR TITLE
Fix stylization of GitHub on vitals page

### DIFF
--- a/src/components/admin/VitalsDashboard.tsx
+++ b/src/components/admin/VitalsDashboard.tsx
@@ -360,7 +360,7 @@ export const VitalsDashboard = () => {
             )})`}
           />
           <DashboardItem
-            name={'Total addresses with mints'}
+            name={'Total issued-to addresses with mints'}
             value={`${totalAddressesWithClaims ?? ''} (${getPercent(
               totalAddressesWithClaims,
               totalAddresses,


### PR DESCRIPTION
Fixes:
* Changes "github" to "GithHub"
* Specifies mints related to addresses are only for `issuedAddress`s