### PR TITLE
Teams Feedback Continued

### DIFF
--- a/src/components/create/FormFields.tsx
+++ b/src/components/create/FormFields.tsx
@@ -111,20 +111,14 @@ export const FormFields = <FormValues extends CreateFormValues | EditFormValues>
                 <TeamSwitcher
                   p={8}
                   mb={0}
+                  dropdownWidth={'target'}
                   styles={{
                     root: {
                       backgroundColor: BackgroundPanel,
                       borderRadius: rem(6),
-                      height: 'auto',
                       '&:hover:not(:disabled)': {
                         backgroundColor: BackgroundPanel2,
                       },
-                    },
-                    inner: {
-                      width: '100%',
-                    },
-                    label: {
-                      width: '100%',
                     },
                   }}
                 />

--- a/src/components/profile/UserMembershipList.tsx
+++ b/src/components/profile/UserMembershipList.tsx
@@ -10,8 +10,8 @@ import { CreateTeamModal } from './CreateTeamModal';
 
 const HEADERS: HeaderItem[] = [
   { label: 'Team', key: 'team', isSortable: false },
-  { label: 'Role', key: 'role', isSortable: false },
   { label: 'Status', key: 'status', isSortable: false },
+  { label: 'Role', key: 'role', isSortable: false },
   { label: 'Joined On', key: 'joinedOn', isSortable: false },
   { label: 'Actions', key: 'actions', isSortable: false },
 ];

--- a/src/components/profile/UserMembershipRow.tsx
+++ b/src/components/profile/UserMembershipRow.tsx
@@ -18,8 +18,8 @@ import { useTeamsContext } from '../team/TeamsContext';
 import { Notifications } from '../../notifications';
 import { TeamLogo } from '../team/settings/TeamLogo';
 
-const TableRow = styled.tr`
-  cursor: pointer;
+const TableRow = styled.tr<{ hasLink: boolean }>`
+  cursor: ${({ hasLink }) => (hasLink ? 'pointer' : 'cursor')};
   &:hover {
     background-color: ${BackgroundPanel2} !important;
   }
@@ -115,13 +115,18 @@ export const UserMembershipRow = ({ membership }: RowProps) => {
   };
 
   const handleClick = async () => {
-    setTeamId(teamId);
+    if (acceptanceStatus === MembershipAcceptanceStatus.Accepted) {
+      setTeamId(teamId);
 
-    await router.push('/app/team/dashboard');
+      await router.push('/app/team/dashboard');
+    }
   };
 
   return (
-    <TableRow onClick={handleClick}>
+    <TableRow
+      hasLink={acceptanceStatus === MembershipAcceptanceStatus.Accepted}
+      onClick={handleClick}
+    >
       <td>
         <Group>
           <TeamLogo name={team.name} size={40} imageUrl={team.logoImageUrl} />
@@ -129,13 +134,17 @@ export const UserMembershipRow = ({ membership }: RowProps) => {
         </Group>
       </td>
       <td>
-        <Text lineClamp={3}>{role}</Text>
-      </td>
-      <td>
         <AcceptanceStatusBadge status={acceptanceStatus} />
       </td>
       <td>
-        <RelativeDate sx={{ whiteSpace: 'nowrap' }} date={DateTime.fromISO(joinedOn)} />
+        <Text lineClamp={3}>{role}</Text>
+      </td>
+      <td>
+        {joinedOn ? (
+          <RelativeDate sx={{ whiteSpace: 'nowrap' }} date={DateTime.fromISO(joinedOn)} />
+        ) : (
+          <Text>{'Not Joined'}</Text>
+        )}
       </td>
       <td>
         {acceptanceStatus === MembershipAcceptanceStatus.Pending && (

--- a/src/components/team/TeamSwitcher.tsx
+++ b/src/components/team/TeamSwitcher.tsx
@@ -1,12 +1,26 @@
 import { Button, ButtonProps, Center, Group, Menu, Text } from '@mantine/core';
 import { rem } from 'polished';
+import { useState } from 'react';
 import { MdKeyboardArrowDown } from 'react-icons/md';
+import { CreateTeamModal } from '../profile/CreateTeamModal';
 import { Header, Loader } from '../shared/elements';
 import { TeamLogo } from './settings/TeamLogo';
 import { useTeamsContext } from './TeamsContext';
 
-export const TeamSwitcher = (props: ButtonProps) => {
+type Props = ButtonProps & {
+  canCreateTeams?: boolean;
+  dropdownWidth?: number | 'target';
+};
+
+export const TeamSwitcher = ({
+  canCreateTeams = false,
+  dropdownWidth: popoverWidth,
+  sx,
+  styles,
+  ...props
+}: Props) => {
   const teams = useTeamsContext();
+  const [isCreateTeamModalOpen, setIsCreateTeamModalOpen] = useState(false);
 
   if (!teams.hasFetchedTeams) {
     return (
@@ -35,11 +49,29 @@ export const TeamSwitcher = (props: ButtonProps) => {
   const currTeam = teams.currTeam;
 
   return (
-    <Menu position="bottom-start">
+    <Menu position="bottom-start" transition="pop" width={popoverWidth}>
       <Menu.Target>
-        <Button mb={rem(16)} p={rem(4)} variant="subtle" {...props}>
-          <Group spacing={12} position="apart" noWrap sx={{ width: '100%' }}>
-            <Group noWrap>
+        <Button
+          mb={rem(16)}
+          p={rem(4)}
+          variant="subtle"
+          sx={{
+            height: 'auto',
+            ...sx,
+          }}
+          styles={{
+            inner: {
+              width: '100%',
+            },
+            label: {
+              width: '100%',
+            },
+            ...styles,
+          }}
+          {...props}
+        >
+          <Group spacing={12} position="apart" noWrap sx={{ width: '100%', maxWidth: '100%' }}>
+            <Group noWrap sx={{ overflow: 'hidden' }}>
               <TeamLogo
                 name={currTeam.name}
                 size={32}
@@ -95,7 +127,18 @@ export const TeamSwitcher = (props: ButtonProps) => {
             )}
           </>
         )}
+        {canCreateTeams && (
+          <Menu.Item onClick={() => setIsCreateTeamModalOpen(true)}>
+            <Center>{'+ CREATE TEAM'}</Center>
+          </Menu.Item>
+        )}
       </Menu.Dropdown>
+      {canCreateTeams && (
+        <CreateTeamModal
+          isOpen={isCreateTeamModalOpen}
+          onClose={() => setIsCreateTeamModalOpen(false)}
+        />
+      )}
     </Menu>
   );
 };

--- a/src/components/team/dashboard/Members/MembershipList.tsx
+++ b/src/components/team/dashboard/Members/MembershipList.tsx
@@ -61,7 +61,7 @@ export const MembershipList = ({ teamId }: Props) => {
       sort: sortBy,
     },
     pause: false,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
 
   const [, removeMember] = useRemoveMembershipMutation();
@@ -126,7 +126,7 @@ export const MembershipList = ({ teamId }: Props) => {
   }
 
   return (
-    <Group position="center" py={0} px={rem(20)}>
+    <Group position="center" py={0}>
       <Stack align="stretch" justify="flex-start" spacing="sm" style={{ width: '100%' }}>
         <Group position="apart" align="center" grow>
           <Header style={{ alignSelf: 'start' }}>{'Members'}</Header>

--- a/src/components/team/dashboard/TeamGitPOAPRequests/index.tsx
+++ b/src/components/team/dashboard/TeamGitPOAPRequests/index.tsx
@@ -1,12 +1,14 @@
-import { Group, Stack, Text, ActionIcon } from '@mantine/core';
+import { Group, Stack, ActionIcon, Button } from '@mantine/core';
 import { useLocalStorage } from '@mantine/hooks';
 import { rem } from 'polished';
 import React, { useState } from 'react';
+import { HiOutlinePlus } from 'react-icons/hi';
 import { MdGridView, MdList } from 'react-icons/md';
 
 import { TextGray, White } from '../../../../colors';
 import { useTeamGitPoapRequestsQuery } from '../../../../graphql/generated-gql';
 import { SelectOption } from '../../../shared/compounds/ItemList';
+import { Link } from '../../../shared/compounds/Link';
 import { Header, Select } from '../../../shared/elements';
 import { TableEmptyState, TableLoader } from '../../../shared/elements/Table';
 import { TeamGitPOAPRequestsGrid } from './Grid';
@@ -44,7 +46,7 @@ export const TeamGitPOAPRequests = ({ teamId }: Props) => {
       sort: sort,
     },
     pause: false,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
 
   const onFilterChange = (filterValue: FilterOptions) => {
@@ -67,6 +69,11 @@ export const TeamGitPOAPRequests = ({ teamId }: Props) => {
         <Group position="apart" align="center" style={{ width: '100%' }}>
           <Header style={{ alignSelf: 'start' }}>{'Requests'}</Header>
           <Group position="right" spacing={32}>
+            <Link href="/create">
+              <Button component="a" leftIcon={<HiOutlinePlus size={20} />}>
+                {'Create'}
+              </Button>
+            </Link>
             <Group spacing="xs">
               <Select data={filterOptions} value={filter} onChange={onFilterChange} />
               <Select data={sortOptions} value={sort} onChange={onSortChange} />
@@ -87,20 +94,15 @@ export const TeamGitPOAPRequests = ({ teamId }: Props) => {
             </Group>
           </Group>
         </Group>
-        {!result.fetching && gitPOAPRequests && gitPOAPRequests.length === 0 && (
-          <Text my={rem(20)} size={18}>
-            {'No GitPOAP Requests Found'}
-          </Text>
-        )}
         {result.fetching ? (
           <TableLoader />
-        ) : !gitPOAPRequests || gitPOAPRequests.length === 0 ? (
-          <TableEmptyState text={'No GitPOAP Requests Found'} />
-        ) : (
+        ) : gitPOAPRequests && gitPOAPRequests.length > 0 ? (
           {
             grid: <TeamGitPOAPRequestsGrid gitPOAPRequests={gitPOAPRequests} />,
             list: <TeamGitPOAPRequestsList gitPOAPRequests={gitPOAPRequests} />,
           }[view]
+        ) : (
+          <TableEmptyState text={'No GitPOAP Requests Found'} />
         )}
       </Stack>
     </Group>

--- a/src/components/team/dashboard/TeamGitPOAPs/index.tsx
+++ b/src/components/team/dashboard/TeamGitPOAPs/index.tsx
@@ -45,7 +45,7 @@ export const TeamGitPOAPs = ({ teamId }: Props) => {
       sort: sort,
     },
     pause: false,
-    requestPolicy: 'network-only',
+    requestPolicy: 'cache-and-network',
   });
 
   const onFilterChange = (filterValue: FilterOptions) => {
@@ -90,13 +90,13 @@ export const TeamGitPOAPs = ({ teamId }: Props) => {
         </Group>
         {result.fetching ? (
           <TableLoader />
-        ) : !gitPOAPs || gitPOAPs.length === 0 ? (
-          <TableEmptyState text={'No GitPOAPs Found'} />
-        ) : (
+        ) : gitPOAPs && gitPOAPs.length > 0 ? (
           {
             grid: <TeamGitPOAPsGrid gitPOAPs={gitPOAPs} />,
             list: <TeamGitPOAPsList gitPOAPs={gitPOAPs} />,
           }[view]
+        ) : (
+          <TableEmptyState text={'No GitPOAPs Found'} />
         )}
       </Stack>
     </Group>

--- a/src/components/team/dashboard/index.tsx
+++ b/src/components/team/dashboard/index.tsx
@@ -1,5 +1,4 @@
 import { Stack } from '@mantine/core';
-import { rem } from 'polished';
 import { CreateAGitPOAP } from './CreateAGitPOAP';
 import { TeamGitPOAPs } from './TeamGitPOAPs';
 
@@ -9,7 +8,7 @@ type Props = {
 
 export const TeamDashboard = ({ teamId }: Props) => {
   return (
-    <Stack pl={rem(32)}>
+    <Stack>
       <CreateAGitPOAP />
       <TeamGitPOAPs teamId={teamId} />
     </Stack>

--- a/src/components/team/index.tsx
+++ b/src/components/team/index.tsx
@@ -1,7 +1,6 @@
-import { Center, Stack, Tabs } from '@mantine/core';
-import { useRouter } from 'next/router';
+import { Center, Grid, NavLink, Stack } from '@mantine/core';
 import { rem } from 'polished';
-import styled from 'styled-components';
+import { Link } from '../shared/compounds/Link';
 import { Header } from '../shared/elements';
 import { TableLoader } from '../shared/elements/Table';
 import { TeamDashboard } from './dashboard';
@@ -10,11 +9,6 @@ import { TeamGitPOAPRequests } from './dashboard/TeamGitPOAPRequests';
 import { TeamSettings } from './settings';
 import { useTeamsContext } from './TeamsContext';
 import { TeamSwitcher } from './TeamSwitcher';
-
-const Panel = styled(Tabs.Panel)`
-  overflow: hidden;
-  width: 100%;
-`;
 
 export enum TeamRoutes {
   Dashboard = 'dashboard',
@@ -28,7 +22,6 @@ type Props = {
 };
 
 export const TeamContainer = ({ page }: Props) => {
-  const router = useRouter();
   const teams = useTeamsContext();
 
   if (!teams.hasFetchedTeams) {
@@ -46,40 +39,34 @@ export const TeamContainer = ({ page }: Props) => {
   const currTeam = teams.currTeam;
 
   return (
-    <Stack m={rem(20)}>
-      <Tabs
-        defaultValue={TeamRoutes.Dashboard}
-        onTabChange={(value) => router.push(`/app/team/${value}`, undefined, { shallow: true })}
-        value={page}
-        orientation="vertical"
-        variant="pills"
-      >
-        <Tabs.List pt={rem(10)}>
-          <TeamSwitcher sx={{ height: 'auto', width: rem(220) }} />
-          <Tabs.Tab value={TeamRoutes.Dashboard}>{'Dashboard'}</Tabs.Tab>
-          <Tabs.Tab value={TeamRoutes.Requests}>{'Requests'}</Tabs.Tab>
-          <Tabs.Tab value={TeamRoutes.Members}>{'Members'}</Tabs.Tab>
-          <Tabs.Tab value={TeamRoutes.Settings}>{'Settings'}</Tabs.Tab>
-        </Tabs.List>
-
-        <Panel value={TeamRoutes.Dashboard}>
-          <TeamDashboard teamId={currTeam.id} />
-        </Panel>
-
-        <Panel value={TeamRoutes.Requests}>
-          <Stack pl={rem(32)}>
-            <TeamGitPOAPRequests teamId={currTeam.id} />
-          </Stack>
-        </Panel>
-
-        <Panel value={TeamRoutes.Members}>
-          <MembershipList teamId={currTeam.id} />
-        </Panel>
-
-        <Panel value={TeamRoutes.Settings}>
-          <TeamSettings teamData={currTeam} />
-        </Panel>
-      </Tabs>
-    </Stack>
+    <Grid p={rem(20)} align="top">
+      <Grid.Col span="content">
+        <Stack p={0} spacing={6}>
+          <TeamSwitcher sx={{ width: rem(220) }} canCreateTeams={true} />
+          <Link href={`/app/team/dashboard`} shallow={true}>
+            <NavLink label={'Dashboard'} active={page === TeamRoutes.Dashboard} />
+          </Link>
+          <Link href={`/app/team/requests`} shallow={true}>
+            <NavLink label={'Requests'} active={page === TeamRoutes.Requests} />
+          </Link>
+          <Link href={`/app/team/members`} shallow={true}>
+            <NavLink label={'Members'} active={page === TeamRoutes.Members} />
+          </Link>
+          <Link href={`/app/team/settings`} shallow={true}>
+            <NavLink label={'Settings'} active={page === TeamRoutes.Settings} />
+          </Link>
+        </Stack>
+      </Grid.Col>
+      <Grid.Col span="auto" pl={20}>
+        {
+          {
+            [TeamRoutes.Dashboard]: <TeamDashboard teamId={currTeam.id} />,
+            [TeamRoutes.Requests]: <TeamGitPOAPRequests teamId={currTeam.id} />,
+            [TeamRoutes.Members]: <MembershipList teamId={currTeam.id} />,
+            [TeamRoutes.Settings]: <TeamSettings teamData={currTeam} />,
+          }[page]
+        }
+      </Grid.Col>
+    </Grid>
   );
 };

--- a/src/graphql/generated-gql.tsx
+++ b/src/graphql/generated-gql.tsx
@@ -9591,7 +9591,16 @@ export function useGitPoapWithClaimsQuery(
 export const UserTeamsDocument = gql`
   query userTeams($address: String!) {
     teams(
-      where: { memberships: { some: { address: { is: { ethAddress: { equals: $address } } } } } }
+      where: {
+        memberships: {
+          some: {
+            AND: [
+              { address: { is: { ethAddress: { equals: $address } } } }
+              { acceptanceStatus: { equals: ACCEPTED } }
+            ]
+          }
+        }
+      }
     ) {
       id
       name

--- a/src/graphql/operations.graphql
+++ b/src/graphql/operations.graphql
@@ -1065,7 +1065,16 @@ query gitPOAPWithClaims(
 
 query userTeams($address: String!) {
   teams(
-    where: { memberships: { some: { address: { is: { ethAddress: { equals: $address } } } } } }
+    where: {
+      memberships: {
+        some: {
+          AND: [
+            { address: { is: { ethAddress: { equals: $address } } } }
+            { acceptanceStatus: { equals: ACCEPTED } }
+          ]
+        }
+      }
+    }
   ) {
     id
     name

--- a/src/lib/theme/index.ts
+++ b/src/lib/theme/index.ts
@@ -14,6 +14,7 @@ import { tabsThemes } from './tabsThemes';
 import { textTheme } from './textThemes';
 import { tooltipThemes } from './tooltipThemes';
 import { selectThemes } from './selectThemes';
+import { navLinkThemes } from './navLinkThemes';
 
 export const theme: MantineProviderProps['theme'] = {
   breakpoints: BREAKPOINTS,
@@ -55,13 +56,7 @@ export const theme: MantineProviderProps['theme'] = {
         },
       },
     },
-    NavLink: {
-      styles: {
-        root: {
-          borderRadius: rem(6),
-        },
-      },
-    },
+    NavLink: navLinkThemes,
     Pagination: paginationThemes,
     Select: selectThemes,
     Tabs: tabsThemes,

--- a/src/lib/theme/navLinkThemes.tsx
+++ b/src/lib/theme/navLinkThemes.tsx
@@ -1,0 +1,25 @@
+import { MantineTheme, NavLinkStylesParams } from '@mantine/core';
+import { rem } from 'polished';
+import { BackgroundPanel, PrimaryBlue, White } from '../../colors';
+
+export const navLinkThemes = {
+  styles: (theme: MantineTheme, params: NavLinkStylesParams) => ({
+    ...((!params.color || params.color === 'blue') && {
+      root: {
+        borderRadius: rem(6),
+        '&:hover': {
+          backgroundColor: BackgroundPanel,
+          '&[data-active]': {
+            backgroundColor: PrimaryBlue,
+          },
+        },
+        '&[data-active]': {
+          backgroundColor: PrimaryBlue,
+        },
+      },
+      label: {
+        color: White,
+      },
+    }),
+  }),
+};


### PR DESCRIPTION
- [x] The GitPOAPs on the gitpoaps tab on the issuer dashboard should cache the results of the network call when going between the gitpoap tab & a specific gitpoap’s manage page.
  - Change all requests to use 'cache-and-network'
- [x] (no need for col sorting though.. or just remove the ability to sort altogether & make it default by permissions) → ‘role’ should sort by permissions, not alphabetically
    - Maybe an overhaul of sorting all together, maybe replace it with column button sorting
- [x] Is it actually sorting by 'joined on' on the 'member's dashboard?
- [x] (take a quick look, there might be something built into mantine) → Possible to add animation to the 'team switcher' popover that appears - on enter specifically?
  - used [pop](https://mantine.dev/core/transition/)
- [x] Add a CTA on the team switcher popover called '+ create team' that brings up the create team modal.
- [x] When i navigate to a team from the "my teams" page... i am greeted with a loading spinner that doesn't go away. I need to refresh and everything is then fine.
- [x] Joined on is irrelevant when I am signing up for a team - feels strange to have it blank, can we have an empty state value `not joined?`
- [x] The most logical default sort on members tab should be Status → Role → Joined On, it feels strange right now to have a pending person in the middle
- [x] Save on blur team settings
- [x] Match width of target on team Switcher
- [x] Ability to CTRL-click on an item on the gitpoaps tab on the issuer dashboard to open ‘manage’ gitpoap in a new tab. Need to surround the component with a Next `<Link>`
- [x] Feels natural to have a `Create a GitPOAP` button on the GitPOAP requests page, that perhaps links back to the dashboard?
- [x] My additions to the list
  - [x] Exclude teams you haven't accepted the invite of from `TeamsContext`
  - [x] Prevent clicking on Teams in the UserMembershipsList on `app/teams` that haven't been accepts -> This should eventually be replaced with a link to their public page
- [ ] Not going to include in this PR 
  - [ ] Would be nice to see who invited me when I’m looking at my invite.
  - [ ] **This needs the public teams page to be created first** Link to the public team page so I can scope it out before accepting, make sure I know it’s the right one