### PR TITLE
Allow GitHub handles that start with 0x

### DIFF
--- a/src/components/create/SelectContributors.tsx
+++ b/src/components/create/SelectContributors.tsx
@@ -25,7 +25,7 @@ import {
 } from '../../colors';
 import { Button, Input, Text, TextArea } from '../shared/elements';
 import Papa from 'papaparse';
-import { isValidGithubHandle, shortenAddress } from '../../helpers';
+import { isValidGitHubHandle, shortenAddress } from '../../helpers';
 import { isAddress } from 'ethers/lib/utils';
 import { VscTrash } from 'react-icons/vsc';
 import { UnvalidatedContributor } from '../../lib/api/gitpoapRequest';
@@ -63,7 +63,7 @@ export const SelectContributors = ({ contributors, addContributor, removeContrib
         return;
       }
 
-      if (isValidGithubHandle(value)) {
+      if (isValidGitHubHandle(value)) {
         addContributor({ type: 'githubHandles', value });
       } else if (isAddress(value)) {
         addContributor({ type: 'ethAddresses', value });

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -43,13 +43,13 @@ export const formatUTCDate = (date: string): string =>
  * Github username cannot begin or end with a hyphen.
  * Maximum is 39 characters.
  */
-export const isValidGithubHandle = (handle: string): boolean =>
+export const isValidGitHubHandle = (handle: string): boolean =>
   /^(?![-])(?!.*[-]{2})(?!.*[-]$)[a-zA-Z0-9-]{1,39}$/.test(handle);
 
 /**
  * Currently Unnused: Temporary validator that prevents the GitHub handle from starting with 0x
  */
-export const isValidGithubHandleWithout0x = (handle: string): boolean =>
+export const isValidGitHubHandleWithout0x = (handle: string): boolean =>
   /^(?![-])(?!0x)(?!.*[-]{2})(?!.*[-]$)[a-zA-Z0-9-]{1,39}$/.test(handle);
 
 export const isValidTwitterHandle = (handle: string): boolean =>

--- a/src/lib/api/gitpoapRequest.ts
+++ b/src/lib/api/gitpoapRequest.ts
@@ -2,7 +2,7 @@ import { validate } from 'email-validator';
 import { isAddress } from 'ethers/lib/utils';
 import { DateTime } from 'luxon';
 import { z } from 'zod';
-import { isValidGithubHandle } from '../../helpers';
+import { isValidGitHubHandle } from '../../helpers';
 import { Notifications } from '../../notifications';
 import { API, makeAPIRequestWithAuth } from './utils';
 import { Tokens } from '../../types';
@@ -37,7 +37,7 @@ export const ValidatedContributorSchema = z.union([
       .string()
       .trim()
       .min(1)
-      .refine((v) => isValidGithubHandle(v)),
+      .refine((v) => isValidGitHubHandle(v)),
   }),
   z.object({
     type: z.literal('ethAddresses'),


### PR DESCRIPTION
Replace use of `isValidGitHubHandleWithout0x` in favor of `isValidGitHubHandle`